### PR TITLE
Add sb-sidenav-primary style

### DIFF
--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*!
 * Start Bootstrap - SB Admin v7.0.7 (https://startbootstrap.com/template/sb-admin)
-* Copyright 2013-2023 Start Bootstrap
+* Copyright 2013-2024 Start Bootstrap
 * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-sb-admin/blob/master/LICENSE)
 */
 /*!
@@ -11074,6 +11074,35 @@ body {
 }
 .sb-sidenav-light .sb-sidenav-footer {
   background-color: #e9ecef;
+}
+
+.sb-sidenav-primary {
+  background-color: #0d6efd;
+  color: rgba(255, 255, 255, 0.9);
+}
+.sb-sidenav-primary .sb-sidenav-menu .sb-sidenav-menu-heading {
+  color: rgba(255, 255, 255, 0.8);
+}
+.sb-sidenav-primary .sb-sidenav-menu .nav-link {
+  color: rgba(255, 255, 255, 0.9);
+}
+.sb-sidenav-primary .sb-sidenav-menu .nav-link .sb-nav-link-icon {
+  color: rgba(255, 255, 255, 0.8);
+}
+.sb-sidenav-primary .sb-sidenav-menu .nav-link .sb-sidenav-collapse-arrow {
+  color: rgba(255, 255, 255, 0.8);
+}
+.sb-sidenav-primary .sb-sidenav-menu .nav-link:hover {
+  color: #fff;
+}
+.sb-sidenav-primary .sb-sidenav-menu .nav-link.active {
+  color: #fff;
+}
+.sb-sidenav-primary .sb-sidenav-menu .nav-link.active .sb-nav-link-icon {
+  color: #fff;
+}
+.sb-sidenav-primary .sb-sidenav-footer {
+  background-color: #052c65;
 }
 
 .datatable-wrapper .datatable-container {

--- a/dist/index.html
+++ b/dist/index.html
@@ -39,7 +39,7 @@
         </nav>
         <div id="layoutSidenav">
             <div id="layoutSidenav_nav">
-                <nav class="sb-sidenav accordion sb-sidenav-dark" id="sidenavAccordion">
+                <nav class="sb-sidenav accordion sb-sidenav-primary" id="sidenavAccordion">
                     <div class="sb-sidenav-menu">
                         <div class="nav">
                             <div class="sb-sidenav-menu-heading">Core</div>

--- a/dist/js/scripts.js
+++ b/dist/js/scripts.js
@@ -1,6 +1,6 @@
 /*!
     * Start Bootstrap - SB Admin v7.0.7 (https://startbootstrap.com/template/sb-admin)
-    * Copyright 2013-2023 Start Bootstrap
+    * Copyright 2013-2024 Start Bootstrap
     * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-sb-admin/blob/master/LICENSE)
     */
     // 

--- a/src/pug/pages/index.pug
+++ b/src/pug/pages/index.pug
@@ -4,7 +4,7 @@ block config
     - var bodyClass = 'sb-nav-fixed'
     - var pageTitle = 'Dashboard';
     - var index = true;
-    - var sidenavStyle = 'sb-sidenav-dark'
+    - var sidenavStyle = 'sb-sidenav-primary'
     
 prepend css
     //- Load Simple DataTables Stylesheet

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -2,8 +2,16 @@
 // Variables
 // 
 
+// See https://getbootstrap.com/docs/5.0/customize/sass/#importing
+
 // Import Bootstrap variables for use within theme
+// 1. Include functions first (so you can manipulate colors, SVGs, calc, etc)
 @import "bootstrap/scss/functions.scss";
+
+// 2. Include any default variable overrides here
+
+
+// 3. Include remainder of required Bootstrap stylesheets
 @import "bootstrap/scss/variables.scss";
 
 // Import spacing variables

--- a/src/scss/navigation/sidenav/_sidenav-primary.scss
+++ b/src/scss/navigation/sidenav/_sidenav-primary.scss
@@ -1,0 +1,45 @@
+// 
+// Sidenav Primary
+// 
+
+// Primary color theme for sidenav
+// Append .sb-sidenav-primary to .sb-sidenav to use
+
+.sb-sidenav-primary {
+    background-color: $sidenav-primary-bg;
+    color: $sidenav-primary-color;
+
+    .sb-sidenav-menu {
+        .sb-sidenav-menu-heading {
+            color: $sidenav-primary-heading-color;
+        }
+
+        .nav-link {
+            color: $sidenav-primary-link-color;
+
+            .sb-nav-link-icon {
+                color: $sidenav-primary-icon-color;
+            }
+
+            .sb-sidenav-collapse-arrow {
+                color: $sidenav-primary-icon-color;
+            }
+
+            &:hover {
+                color: $sidenav-primary-link-active-color;
+            }
+
+            &.active {
+                color: $sidenav-primary-link-active-color;
+
+                .sb-nav-link-icon {
+                    color: $sidenav-primary-link-active-color;
+                }
+            }
+        }
+    }
+
+    .sb-sidenav-footer {
+        background-color: $sidenav-primary-footer-bg;
+    }
+}

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -2,7 +2,9 @@
 // Styles
 // 
 
-// Import Custom Variables
+// See https://getbootstrap.com/docs/5.0/customize/sass/#importing
+
+// Import Custom Variables (note that this imports some bootstrap variables too)
 @import "variables.scss";
 
 // Import Bootstrap
@@ -23,6 +25,7 @@
 @import "navigation/sidenav/sidenav.scss";
 @import "navigation/sidenav/sidenav-dark.scss";
 @import "navigation/sidenav/sidenav-light.scss";
+@import "navigation/sidenav/sidenav-primary.scss";
 
 // Plugins
 @import "plugins/simple-datatables.scss";

--- a/src/scss/variables/_navigation.scss
+++ b/src/scss/variables/_navigation.scss
@@ -27,6 +27,15 @@ $sidenav-light-link-active-color: $primary;
 $sidenav-light-icon-color: $gray-500;
 $sidenav-light-footer-bg: $gray-200;
 
+// -- Sidenav Dark
+$sidenav-primary-bg: $primary;
+$sidenav-primary-color: fade-out($white, 0.1);
+$sidenav-primary-heading-color: fade-out($white, 0.2);
+$sidenav-primary-link-color: fade-out($white, 0.1);
+$sidenav-primary-link-active-color: $white;
+$sidenav-primary-icon-color: fade-out($white, 0.2);
+$sidenav-primary-footer-bg: $blue-800;
+
 // Color variables for the topnav
 $topnav-dark-toggler-color: fade-out($white, 0.5);
 $topnav-light-toggler-color: $gray-900;


### PR DESCRIPTION
We want to have a style that uses the primary color (blue, in this case) as the background color for the sidenav.

To use, just add `sb-sidenav-primary` to existing sidenav.

**New Style:**
![image](https://github.com/Liturgical-Calendar/startbootstrap-sb-admin/assets/12214617/eaf04b84-bf87-4027-bf1a-8127a92a0dec)

**Original:**
![image](https://github.com/Liturgical-Calendar/startbootstrap-sb-admin/assets/12214617/a7ec5336-6e23-4bfc-8f77-6a54d9d33476)
